### PR TITLE
response.body is undefined on firefox browser

### DIFF
--- a/jakecache-sw.js
+++ b/jakecache-sw.js
@@ -26,22 +26,15 @@ class JakeCacheManifest {
         return Promise.reject()
       }
 
-      var reader = response.body.getReader()
-      var decoded = ''
-      var decoder = new TextDecoder()
       this._rawData = {
         cache: [],
         fallback: [],
         network: []
       }
 
-      return reader.read().then((result) => {
+      return response.text().then((result) => {
         return new Promise((resolve, reject) => {
-          decoded += decoder.decode(result.value || new Uint8Array(), {
-            stream: !result.done
-          })
-
-          let hash = md5(decoded)
+          let hash = md5(result)
           if (this._hash && hash.toString() === this._hash.toString()) {
             console.log('noupdate: ' + hash)
             return resolve(false)
@@ -49,7 +42,7 @@ class JakeCacheManifest {
           this._hash = hash
           console.log(`update: ${hash} (was: ${this._hash})`)
 
-          let lines = decoded.split(/\r|\n/)
+          let lines = result.split(/\r|\n/)
           let header = 'cache' // default.
 
           let firstLine = lines.shift()

--- a/jakecache-sw.js
+++ b/jakecache-sw.js
@@ -76,7 +76,7 @@ class JakeCacheManifest {
             this._rawData[header].push(line)
           }
 
-          this.cache = ['/jakecache.js']
+          this.cache = ['jakecache.js']
           // Ignore different protocol
           for (let pathname of this._rawData.cache) {
             let path = new URL(pathname, location)


### PR DESCRIPTION
Unfortunately the response.body property does not exist on firefox browser (v52). So why not just use the response.text without the reader and decoding?