### PR TITLE
setting same-origin policy for created request objects

### DIFF
--- a/dist/jakecache.js
+++ b/dist/jakecache.js
@@ -65,7 +65,7 @@ const _status = Symbol('status')
 
 class JakeCache extends PolyfilledEventTarget {
   constructor () {
-    super(['bort', 'cached', 'checking',
+    super(['abort', 'cached', 'checking',
            'downloading', 'error', 'obsolete',
            'progress', 'updateready', 'noupdate'])
 
@@ -73,6 +73,10 @@ class JakeCache extends PolyfilledEventTarget {
       return window.jakeCache
     }
     window.jakeCache = this
+    
+    if (('serviceWorker' in navigator) === false) {
+      return
+    }
 
     let onload = () => {
       if (document.readyState !== 'complete') {
@@ -83,7 +87,7 @@ class JakeCache extends PolyfilledEventTarget {
       this.pathname = html.getAttribute('manifest')
 
       if (this.pathname && 'serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/jakecache-sw.js').then(registration => {
+        navigator.serviceWorker.register('jakecache-sw.js').then(registration => {
           console.log(`JakeCache installed for ${registration.scope}`)
 
           if (registration.active) {

--- a/jakecache-sw.js
+++ b/jakecache-sw.js
@@ -6,6 +6,7 @@ class JakeCacheManifest {
     this._path = null
     this._hash = null
     this._isValid = false
+    this._fetchOptions = { credentials: "same-origin" }
   }
 
   groupName () {
@@ -21,7 +22,7 @@ class JakeCacheManifest {
     }
 
     // http://html5doctor.com/go-offline-with-application-cache/
-    return fetch(new Request(this._path, options)).then((response) => {
+    return fetch(new Request(this._path, options), this._fetchOptions).then((response) => {
       if (response.type === 'opaque' || response.status === 404 || response.status === 410) {
         return Promise.reject()
       }
@@ -234,7 +235,7 @@ function update (pathname, options = {}) {
 
     return Promise.all(this.requests.map(request => {
       // Manual fetch to emulate appcache behavior.
-      return fetch(request).then(response => {
+      return fetch(request, manifest._fetchOptions).then(response => {
         cacheStatus = CacheStatus.PROGRESS
         postMessage({
           type: 'progress',


### PR DESCRIPTION
Setting same-origin policy for created request objects. Otherwise the requests for the manifest entries may be rejected as unauthorized.
Also the dist/* files are updated with a current build (the PR included) 