### PR TITLE
keep service worker alive until update is done

### DIFF
--- a/jakecache-sw.js
+++ b/jakecache-sw.js
@@ -116,7 +116,7 @@ class JakeCacheManifest {
 self.addEventListener('message', function (event) {
   switch (event.data.command) {
     case 'update':
-      update.call(this, event.data.pathname, event.data.options)
+      event.waitUntil(update.call(this, event.data.pathname, event.data.options))
       break
     case 'abort':
       postMessage({ type: 'error', message: 'Not implementable without cancellable promises.' })


### PR DESCRIPTION
if the update takes longer than 30 seconds the service worker will be stopped. this change extends the timeout to allow jakecache to live on and cache.